### PR TITLE
Logo Resizing Mobile

### DIFF
--- a/src/Components/Logo/Logo.scss
+++ b/src/Components/Logo/Logo.scss
@@ -1,6 +1,11 @@
 //Logo scss
+@import '../../scss/Base/mixins';
 
 .logo {
-  width: 80px;
+  width: 50px;
   vertical-align: bottom;
+
+  @include breakpoint('medium') {
+    width: 80px;
+  }
 }


### PR DESCRIPTION
* Adds Breakpoint 'Medium' to resize the Logo to 80px. Default set to 50px